### PR TITLE
`lwt_domain` is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Repository: https://github.com/talex5/lwt_eio
 
 Repository: https://github.com/ocsigen/lwt
 
-Not yet released, [upstream lwt](https://github.com/ocsigen/lwt/tree/master/src/domain) now has a package called `lwt-domain`. This provides useful functions for programming with Lwt and [Domainslib](#domainslib).
+Lwt now has a package called [`lwt-domain`](https://github.com/ocsigen/lwt/tree/master/src/domain). This provides useful functions for programming with Lwt and [Domainslib](#domainslib).
 
 ## Experiments
 


### PR DESCRIPTION
It was released along with Lwt 5.5.0, it works on older Lwt versions as well (from 3.0.0).

(cf. https://discuss.ocaml.org/t/ann-lwt-5-5-0-lwt-domain-0-1-0-lwt-react-1-1-5/8897)